### PR TITLE
avoid #4 with new version of line_profiler

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@
    - numpy
    - matplotlib
    - numba=0.26.0
-   - line_profiler
    - jupyter
    - ipython
+   - pip:
+     - line-profiler==2.0


### PR DESCRIPTION
line_profiler 2.0 is now available via pip. Installing 2.0 avoids #4 