### PR TITLE
Optimize Cython code a bit

### DIFF
--- a/notebooks/05.2.optional.Numba.v.Cython.v.Fortran.ipynb
+++ b/notebooks/05.2.optional.Numba.v.Cython.v.Fortran.ipynb
@@ -4,7 +4,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
    },
    "outputs": [],
    "source": [
@@ -16,7 +22,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
    },
    "outputs": [],
    "source": [
@@ -27,7 +39,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
    },
    "outputs": [],
    "source": [
@@ -52,7 +70,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
    },
    "outputs": [],
    "source": [
@@ -62,14 +86,20 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Other options for accelerating Python code"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Cython"
    ]
@@ -78,7 +108,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
    },
    "outputs": [],
    "source": [
@@ -89,11 +125,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
    },
    "outputs": [],
    "source": [
     "%%cython\n",
+    "#%%cython -a\n",
+    "\n",
     "cimport numpy\n",
     "cimport cython\n",
     "\n",
@@ -101,14 +145,18 @@
     "\n",
     "from libc.math cimport sqrt\n",
     "\n",
+    "\n",
     "@cython.boundscheck(False)\n",
+    "@cython.wraparound(False)\n",
+    "@cython.cdivision(True)\n",
+    "@cython.embedsignature(True)\n",
     "def pressure_poisson(numpy.ndarray[numpy.float_t, ndim=2] p,\n",
     "                     numpy.ndarray[numpy.float_t, ndim=2] b,\n",
     "                     double l2_target):\n",
     "\n",
     "    cdef numpy.ndarray[numpy.float_t, ndim=2] pn = numpy.zeros_like(p)\n",
     "    cdef int i, j, n\n",
-    "    cdef double iter_diff\n",
+    "    cdef double s1, s2, iter_diff\n",
     "    cdef int I = b.shape[0]\n",
     "    cdef int J = b.shape[1]\n",
     "\n",
@@ -127,14 +175,20 @@
     "\n",
     "        for i in range(I):\n",
     "            p[i, 0] = p[i, 1]\n",
-    "            p[i, -1] = 0\n",
+    "            p[i, J-1] = 0\n",
     "\n",
     "        for j in range(J):\n",
     "            p[0, j] = p[1, j]\n",
-    "            p[-1, j] = p[-2, j]\n",
+    "            p[I-1, j] = p[I-2, j]\n",
     "\n",
     "        if n % 10 == 0:\n",
-    "            iter_diff = sqrt(numpy.sum((p - pn)**2)/numpy.sum(pn**2))\n",
+    "            s1 = 0.0\n",
+    "            s2 = 0.0\n",
+    "            for i in range(I):\n",
+    "                for j in range(J):\n",
+    "                    s1 += (p[i, j] - pn[i, j])**2\n",
+    "                    s2 += pn[i, j]**2\n",
+    "            iter_diff = sqrt(s1 / s2)\n",
     "\n",
     "        n += 1\n",
     "\n",
@@ -145,7 +199,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
    },
    "outputs": [],
    "source": [
@@ -156,7 +216,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
    },
    "outputs": [],
    "source": [
@@ -168,7 +234,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Fortran and `f2py`"
    ]
@@ -177,11 +246,35 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
    },
    "outputs": [],
    "source": [
-    "%%file pressure_poisson_F.f90\n",
+    "%load_ext fortranmagic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%fortran\n",
+    "#%%fortran -vvv\n",
     "\n",
     "SUBROUTINE pressure_poisson(p, b, M, N, l2_target)\n",
     "IMPLICIT NONE\n",
@@ -224,33 +317,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "!f2py3 -c --fcompiler=gnu95 \\\n",
-    "      --f90flags= --f77flags= --opt=\"-m64 -O4\" \\\n",
-    "      -m pressure_poisson_F pressure_poisson_F.f90 \\\n",
-    "      -DF2PY_REPORT_ON_ARRAY_COPY=1 \\\n",
-    "      > /dev/null"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "from pressure_poisson_F import pressure_poisson"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
    },
    "outputs": [],
    "source": [
@@ -261,7 +334,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
    },
    "outputs": [],
    "source": [
@@ -273,6 +352,7 @@
   }
  ],
  "metadata": {
+  "hide_input": false,
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -288,7 +368,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Here I implemented the changes mentioned in #6. It makes the Cython version run faster. Depending on the machine, it's slightly slower or on par with the Fortran version.

I also changed the Fortran version to use the IPython magic for Fortran. It makes the convenience comparable to Cython. If you want to keep it, `fortran-magic` needs to be added as a dependency. It is not available in Anaconda, but `pip` has it.